### PR TITLE
Update quality-action.yml

### DIFF
--- a/.github/workflows/quality-action.yml
+++ b/.github/workflows/quality-action.yml
@@ -21,5 +21,5 @@ jobs:
       run: go install github.com/mattn/goveralls@latest
     - name: Send coverage
       env:
-        COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=covprofile -service=github


### PR DESCRIPTION
First (and also last) build return the following error message:

```
{"message":"Couldn't find a repository matching this job.","error":true}
```

It looks like the COVEALLS_TOKEN is wrong.
