### PR TITLE
Fix '-str' handling for the glob import to enable 'importstr'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ models
 
 
 <details>
-  <summary><h4>Prefix `glob.<?>` And `glob.<?>+`</h4></summary>
+  <summary><h4>Prefix `glob.&lt;?&gt;` And `glob.&lt;?&gt;+`</h4></summary>
 
 - Each resolved file, which matched the glob pattern, will be handled individually and will be available in the code under a specific variable name. The variable name can be specified in the `<?>` part.
 - `<?>` can be one of the following options:
@@ -188,24 +188,6 @@ Code which will be evaluated in jsonnet:
    grafana: (import 'models/development/grafana.libsonnet') + (import 'models/production/grafana.libsonnet'),
    victor_ops: import 'models/production/victor_ops.libsonnet',
  }
-```
-
-##### Example Input `glob.stem+!`
-
-```jsonnet
-import 'glob.stem+!models/**/*grafana*://models/**/*.libsonnet'
-```
-
-##### Example Result `glob.stem+!`
-
-```jsonnet
-{
-  blackbox_exporter: import 'models/blackbox_exporter.libsonnet',
-  node_exporter: import 'models/node_exporter.libsonnet',
-  wavefront: import 'models/wavefront.libsonnet',
- 
-  victor_ops: import 'models/production/victor_ops.libsonnet',
-}
 ```
 
 </details>

--- a/glob.go
+++ b/glob.go
@@ -416,8 +416,8 @@ func (g GlobImporter) handle(files []string, prefix string) (string, error) {
 	// handle import or importstr
 	importKind := "import"
 
-	if strings.HasPrefix(prefix, "-str") {
-		prefix = strings.TrimPrefix(prefix, "-str")
+	if strings.HasPrefix(prefix, "glob-str") {
+		prefix = strings.Replace(prefix, "glob-str", "glob", 1)
 		importKind += "str"
 	}
 
@@ -481,7 +481,7 @@ func createGlobDotImportsFrom(resolvedFiles *orderedMap) string {
 		fmt.Fprintf(&out, "'%s': %s,\n", k, strings.Join(resolvedFiles.items[k], "+"))
 	}
 
-	out.WriteString("\n}")
+	out.WriteString("}")
 
 	return out.String()
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -337,3 +337,71 @@ func TestGlobImporter_Import(t *testing.T) {
 		})
 	}
 }
+
+func TestGlobImporter_handle(t *testing.T) {
+	type fields struct {
+		aliases map[string]string
+	}
+	type args struct {
+		files  []string
+		prefix string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "glob-str+",
+			args: args{
+				files:  []string{"a.jsonnet", "b.jsonnet"},
+				prefix: "glob-str+",
+			},
+			want:    `(importstr 'a.jsonnet')+(importstr 'b.jsonnet')`,
+			wantErr: false,
+		},
+		{
+			name: "glob+",
+			args: args{
+				files:  []string{"a.jsonnet", "b.jsonnet"},
+				prefix: "glob+",
+			},
+			want:    `(import 'a.jsonnet')+(import 'b.jsonnet')`,
+			wantErr: false,
+		},
+		// ---------------------------------------------------------- glob.file
+		{
+			name: "glob.file",
+			args: args{
+				files:  []string{"a.jsonnet", "b.jsonnet"},
+				prefix: "glob.file",
+			},
+			want:    "{\n'a.jsonnet': (import 'a.jsonnet'),\n'b.jsonnet': (import 'b.jsonnet'),\n}",
+			wantErr: false,
+		},
+		{
+			name: "glob-str.file",
+			args: args{
+				files:  []string{"a.jsonnet", "b.jsonnet"},
+				prefix: "glob-str.file",
+			},
+			want:    "{\n'a.jsonnet': (importstr 'a.jsonnet'),\n'b.jsonnet': (importstr 'b.jsonnet'),\n}",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGlobImporter()
+			g.aliases = tt.fields.aliases
+
+			got, err := g.handle(tt.args.files, tt.args.prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GlobImporter.handle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- Fix glob examples in the readme file.
- Remove old exclude pattern example from the readme file.